### PR TITLE
Add highlighting of cell in chat list when returning to screen

### DIFF
--- a/Display/ListView.swift
+++ b/Display/ListView.swift
@@ -3666,6 +3666,9 @@ open class ListView: ASDisplayNode, UIScrollViewAccessibilityDelegate, UIGesture
         self.highlightedItemIndex = nil
     }
     
+    open func updateHiglightPercent(_ percent: CGFloat) {
+    }
+    
     public func updateNodeHighlightsAnimated(_ animated: Bool) {
         let transition: ContainedViewLayoutTransition = animated ? .animated(duration: 0.35, curve: .spring) : .immediate
         self.updateOverlayHighlight(transition: transition)

--- a/Display/ListViewItemNode.swift
+++ b/Display/ListViewItemNode.swift
@@ -522,6 +522,10 @@ open class ListViewItemNode: ASDisplayNode {
     open func setHighlighted(_ highlighted: Bool, at point: CGPoint, animated: Bool) {
     }
     
+    open func setHighlightedPercent(_ percent: CGFloat) -> Bool {
+        return false
+    }
+    
     open func isReorderable(at point: CGPoint) -> Bool {
         return false
     }

--- a/Display/NavigationController.swift
+++ b/Display/NavigationController.swift
@@ -420,7 +420,8 @@ open class NavigationController: UINavigationController, ContainableController, 
                 
                 if let _ = previousControllers.index(where: { $0.controller === record.controller }) {
                     //previousControllers[index].transition = .appearance
-                    let navigationTransitionCoordinator = NavigationTransitionCoordinator(transition: .Pop, container: self.controllerView.containerView, topView: previousController.view, topNavigationBar: (previousController as? ViewController)?.navigationBar, bottomView: record.controller.view, bottomNavigationBar: (record.controller as? ViewController)?.navigationBar)
+                    let transitionType: NavigationTransition = .Pop
+                    let navigationTransitionCoordinator = NavigationTransitionCoordinator(transition: transitionType, container: self.controllerView.containerView, topView: previousController.view, topNavigationBar: (previousController as? ViewController)?.navigationBar, bottomView: record.controller.view, bottomNavigationBar: (record.controller as? ViewController)?.navigationBar, alongsideTransition: (record.controller as? ViewController)?.navigationAlongsideTransition(type: transitionType))
                     self.navigationTransitionCoordinator = navigationTransitionCoordinator
                     
                     self.controllerView.inTransition = true
@@ -684,7 +685,8 @@ open class NavigationController: UINavigationController, ContainableController, 
                         bottomController.displayNode.recursivelyEnsureDisplaySynchronously(true)
                     }
                     
-                    let navigationTransitionCoordinator = NavigationTransitionCoordinator(transition: .Pop, container: self.controllerView.containerView, topView: topView, topNavigationBar: (topController as? ViewController)?.navigationBar, bottomView: bottomView, bottomNavigationBar: (bottomController as? ViewController)?.navigationBar)
+                    let transitionType: NavigationTransition = .Pop
+                    let navigationTransitionCoordinator = NavigationTransitionCoordinator(transition: transitionType, container: self.controllerView.containerView, topView: topView, topNavigationBar: (topController as? ViewController)?.navigationBar, bottomView: bottomView, bottomNavigationBar: (bottomController as? ViewController)?.navigationBar, alongsideTransition: (bottomController as? ViewController)?.navigationAlongsideTransition(type: transitionType))
                     self.navigationTransitionCoordinator = navigationTransitionCoordinator
                 }
             case UIGestureRecognizerState.changed:

--- a/Display/NavigationTransitionCoordinator.swift
+++ b/Display/NavigationTransitionCoordinator.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-enum NavigationTransition {
+public enum NavigationTransition {
     case Push
     case Pop
 }
@@ -14,15 +14,8 @@ private func generateShadow() -> UIImage? {
 private let shadowImage = generateShadow()
 
 class NavigationTransitionCoordinator {
-    private var _progress: CGFloat = 0.0
-    var progress: CGFloat {
-        get {
-            return self._progress
-        }
-        set(value) {
-            self._progress = value
-            self.updateProgress()
-        }
+    var progress: CGFloat = 0 {
+        didSet { updateProgress() }
     }
     
     private let container: UIView
@@ -39,9 +32,11 @@ class NavigationTransitionCoordinator {
     
     private(set) var animatingCompletion = false
     private var currentCompletion: (() -> Void)?
+    private let alongsideTransition: ((CGFloat) -> ())?
     
-    init(transition: NavigationTransition, container: UIView, topView: UIView, topNavigationBar: NavigationBar?, bottomView: UIView, bottomNavigationBar: NavigationBar?) {
+    init(transition: NavigationTransition, container: UIView, topView: UIView, topNavigationBar: NavigationBar?, bottomView: UIView, bottomNavigationBar: NavigationBar?, alongsideTransition: ((CGFloat) ->())? = nil) {
         self.transition = transition
+        self.alongsideTransition = alongsideTransition
         self.container = container
         self.topView = topView
         switch transition {
@@ -86,6 +81,8 @@ class NavigationTransitionCoordinator {
     }
     
     func updateProgress() {
+        alongsideTransition?(progress)
+        
         let position: CGFloat
         switch self.transition {
             case .Push:

--- a/Display/TabBarController.swift
+++ b/Display/TabBarController.swift
@@ -134,6 +134,10 @@ open class TabBarController: ViewController {
         return self.tabBarControllerNode.tabBarNode.sourceNodesForController(at: index)
     }
     
+    override open func navigationAlongsideTransition(type: NavigationTransition) -> ((CGFloat) -> ())? {
+        return currentController?.navigationAlongsideTransition(type: type)
+    }
+    
     override open func loadDisplayNode() {
         self.displayNode = TabBarControllerNode(theme: self.theme, navigationBar: self.navigationBar, itemSelected: { [weak self] index, longTap, itemNodes in
             if let strongSelf = self {

--- a/Display/ViewController.swift
+++ b/Display/ViewController.swift
@@ -186,6 +186,10 @@ open class ViewControllerPresentationArguments {
         }
     }
     
+    open func navigationAlongsideTransition(type: NavigationTransition) -> ((CGFloat) -> ())? {
+        return nil
+    }
+    
     private let _ready = Promise<Bool>(true)
     open var ready: Promise<Bool> {
         return self._ready


### PR DESCRIPTION
There is a good UX practice in iOS apps to leave the list cell selection on, until the user returns to the screen with the list. This helps the user to better understand the point from which his forward navigation started. A good example of this is the standard iOS Settings app (settings.mp4). So this is not a fix, but rather a UX improvement with respect to the iOS develpment best practices.

Has to merged together with https://github.com/peter-iakovlev/TelegramUI/pull/15