### PR TITLE
Close delete button when editing is over

### DIFF
--- a/Display/ListView.swift
+++ b/Display/ListView.swift
@@ -3563,6 +3563,14 @@ open class ListView: ASDisplayNode, UIScrollViewAccessibilityDelegate, UIGesture
         
         self.checkItemReordering()
     }
+
+    public func dismissAllRevealOptions() {
+        for i in 0 ..< self.itemNodes.count {
+            if self.itemNodes[i].preventsTouchesToOtherItems {
+                self.itemNodes[i].touchesToOtherItemsPrevented()
+            }
+        }
+    }
     
     override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         let touchesPosition = touches.first!.location(in: self.view)


### PR DESCRIPTION
There is a small UX inaccuracy in the calls list screen.
Calls -> Edit -> Tap one of the minus icons -> Tap Done
Expected behavior: The editing menu of the cell is dismissed together with the editing mode of the whole screen.
Actual behavior: The cell's editing menu is not dismissed.
This problem is present in many screens that allow editing of the list, I just made a fix for this screen.

Has to be merged together with https://github.com/peter-iakovlev/TelegramUI/pull/16