### PR TITLE
Fix container layout input inset

### DIFF
--- a/Display/ContainerViewLayout.swift
+++ b/Display/ContainerViewLayout.swift
@@ -63,7 +63,7 @@ public struct ContainerViewLayout: Equatable {
             insets.top += statusBarHeight
         }
         if let inputHeight = self.inputHeight , options.contains(.input) {
-            insets.bottom = max(inputHeight, insets.bottom)
+            insets.bottom += inputHeight
         }
         return insets
     }


### PR DESCRIPTION
Bug. Archive undo view is partly visible and untouchable on iPad with keyboard shown.

Technical description: Container layout considers input or intrinsic insets.It should take both into account. I Summed input and intrinsic insets.